### PR TITLE
Add a set function

### DIFF
--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -13,6 +13,7 @@ module Matrix exposing
     , get
     , getRow
     , getColumn
+    , set
     , toArray
     )
 
@@ -377,6 +378,31 @@ getColumn x m =
         A.empty
         m
         |> arrMb2ResArr
+
+
+
+
+{-| Set the element at a particular index. Returns an updated array. 
+If the index is out of range, the matrix is unaltered.
+
+    myMatrix =
+        generate 4 4 (\x y -> String.fromInt x ++ String.fromInt y)
+            |> set 1 2 "**"
+
+    --  "00"    "10"    "20"    "30"
+    --  "01"    "11"    "21"    "31"
+    --  "02"    "**"    "22"    "32"
+    --  "03"    "13"    "23"    "33"
+
+-}
+set : Int -> Int -> a -> Matrix a -> Matrix a
+set x y a m =
+    case A.get y m of
+        Just row ->
+            A.set y (A.set x a row) m
+
+        Nothing ->
+            m
 
 
 {-| Returns all elements of matrix in a single array.

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -71,6 +71,8 @@ These are just standard traversal functions.
 
 @docs getColumn
 
+@docs set
+
 @docs toArray
 
 -}


### PR DESCRIPTION
Hi,

The "set" function is missing. I've designed this one cloning the Array.set function : if the indices are out of bounds, the function only returns the matrix unaltered.

I've considered a `setRow` and `setColumn` but it seems a bit tricky since we need to check the matrix dimensions before inserting... It may be easier if the `Matrix` type be something like `type Matrix a = Matrix { width: Int, height, content : Array (Array a)}` (which will make the type opaque and then ensure we can not do crazy things with the dimensions).