### PR TITLE
Make Matrix an opaque type

### DIFF
--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -25,7 +25,7 @@ Exposes Matrix creation, traversal, and some manipulation functions.
 
 # Definition
 
-Matrix is just nested array with a constraint that all sub-arrays must be of same length
+Matrix 
 
 @docs Matrix
 
@@ -79,12 +79,13 @@ These are just standard traversal functions.
 
 import Array as A exposing (..)
 
+type alias Width = Int
 
-{-| This is not a way to create a matrix, just a type alias.
-For creation use some of cretion functions.
+{-| A type representing a matrix. Internally, a matrix is just nested array 
+with a constraint that all sub-arrays must be of same length
 -}
-type alias Matrix a =
-    Array (Array a)
+type Matrix a =
+    Matrix Width (Array (Array a))
 
 
 {-| Creates Matrix of given width and height
@@ -102,8 +103,9 @@ Call `repeat` with width and height, and a value to be repeated.
 
 -}
 repeat : Int -> Int -> a -> Matrix a
-repeat w h =
-    A.repeat w >> A.repeat h
+repeat w h a=
+    Matrix w <|
+        (A.repeat w  (A.repeat h a))
 
 
 {-| Creates Matrix of given width and height by calling a generator function.
@@ -131,13 +133,14 @@ Generator function will be called for every element of matrix and will receive `
 -}
 generate : Int -> Int -> (Int -> Int -> a) -> Matrix a
 generate w h f =
-    A.map
-        (\y ->
-            A.map
-                (\x -> f x y)
-                (A.initialize w identity)
-        )
-        (A.initialize h identity)
+    Matrix w <|
+        A.map
+            (\y ->
+                A.map
+                    (\x -> f x y)
+                    (A.initialize w identity)
+            )
+            (A.initialize h identity)
 
 
 {-| indexedMap will call your function with `x`, `y` and `a` as params
@@ -155,13 +158,15 @@ generate w h f =
 
 -}
 indexedMap : (Int -> Int -> a -> b) -> Matrix a -> Matrix b
-indexedMap f =
-    A.indexedMap
-        (\y row ->
-            A.indexedMap
-                (\x ele -> f x y ele)
-                row
-        )
+indexedMap f  (Matrix w m) =
+    Matrix w <|
+        A.indexedMap
+            (\y row ->
+                A.indexedMap
+                    (\x ele -> f x y ele)
+                    row
+            )
+            m
 
 
 {-| Jup, it's a map
@@ -177,13 +182,15 @@ indexedMap f =
 
 -}
 map : (a -> b) -> Matrix a -> Matrix b
-map f =
-    A.map
-        (\row ->
-            A.map
-                (\ele -> f ele)
-                row
-        )
+map f (Matrix w m) =
+    Matrix w <|
+        A.map
+            (\row ->
+                A.map
+                    (\ele -> f ele)
+                    row
+            )
+            m
 
 
 {-| Folding right
@@ -198,7 +205,7 @@ map f =
 
 -}
 foldr : (a -> b -> b) -> b -> Matrix a -> b
-foldr f =
+foldr f acc (Matrix _ m)=
     A.foldr
         (\row bc ->
             A.foldr
@@ -206,6 +213,8 @@ foldr f =
                 bc
                 row
         )
+        acc
+        m
 
 
 {-| Folding left
@@ -220,7 +229,7 @@ foldr f =
 
 -}
 foldl : (a -> b -> b) -> b -> Matrix a -> b
-foldl f =
+foldl f acc (Matrix _ m) =
     A.foldl
         (\row bc ->
             A.foldl
@@ -228,6 +237,8 @@ foldl f =
                 bc
                 row
         )
+        acc
+        m
 
 
 {-| Returns height of given Matrix
@@ -241,8 +252,8 @@ foldl f =
 
 -}
 height : Matrix a -> Int
-height =
-    A.length
+height (Matrix _ m) =
+    A.length m
 
 
 {-| Returns width of given Matrix
@@ -256,8 +267,8 @@ height =
 
 -}
 width : Matrix a -> Int
-width =
-    A.get 0 >> Maybe.withDefault A.empty >> A.length
+width (Matrix w _) =
+    w
 
 
 {-| Concatinates two matrices horizontally.
@@ -275,20 +286,20 @@ Will return Result Err if matrices are not of same height.
 
 -}
 concatHorizontal : Matrix a -> Matrix a -> Result String (Matrix a)
-concatHorizontal m n =
-    if height m == height n then
+concatHorizontal (Matrix w1 m) ((Matrix w2 n) as m2) =
+    if A.length m == A.length n then
         Ok <|
-            A.indexedMap
-                (\i mrow ->
-                    getRow i n
-                        |> Result.withDefault A.empty
-                        |> A.append mrow
-                )
-                m
+            Matrix (w1 + w2) <|
+                A.indexedMap
+                    (\i mrow ->
+                        getRow i m2
+                            |> Result.withDefault A.empty
+                            |> A.append mrow
+                    )
+                    m
 
     else
         Err "Matrix: matrices are of different height"
-
 
 {-| Concatinates two matrices vertically.
 Will return Result Err if matrices are not of same width.
@@ -307,9 +318,10 @@ Will return Result Err if matrices are not of same width.
 
 -}
 concatVertical : Matrix a -> Matrix a -> Result String (Matrix a)
-concatVertical m n =
-    if width m == width n then
-        Ok <| A.append m n
+concatVertical (Matrix w1 m) (Matrix w2 n) =
+    if w1 == w2 then
+        Ok <|
+            Matrix w1 (A.append m n)
 
     else
         Err "Matrix: matrices are of different width"
@@ -328,7 +340,7 @@ Nothing of indexes are out of bounds.
 
 -}
 get : Int -> Int -> Matrix a -> Result String a
-get x y m =
+get x y (Matrix _ m) =
     case m |> (A.get y >> Maybe.withDefault A.empty >> A.get x) of
         Nothing ->
             Err "Matrix: Location out of bounds"
@@ -350,7 +362,7 @@ Result Err if index is out of bounds.
 
 -}
 getRow : Int -> Matrix a -> Result String (Array a)
-getRow y m =
+getRow y (Matrix _ m) =
     case A.get y m of
         Just x ->
             Ok x
@@ -374,7 +386,7 @@ Result Err if index is out of bounds.
 
 -}
 getColumn : Int -> Matrix a -> Result String (Array a)
-getColumn x m =
+getColumn x (Matrix _ m) =
     A.foldr
         (\row c -> A.push (A.get x row) c)
         A.empty
@@ -398,13 +410,14 @@ If the index is out of range, the matrix is unaltered.
 
 -}
 set : Int -> Int -> a -> Matrix a -> Matrix a
-set x y a m =
-    case A.get y m of
-        Just row ->
-            A.set y (A.set x a row) m
+set x y a (Matrix w m) =
+    Matrix w <|
+        case A.get y m of
+            Just row ->
+                A.set y (A.set x a row) m
 
-        Nothing ->
-            m
+            Nothing ->
+                m
 
 
 {-| Returns all elements of matrix in a single array.
@@ -421,8 +434,8 @@ set x y a m =
 
 -}
 toArray : Matrix a -> Array a
-toArray =
-    A.foldr A.append A.empty
+toArray (Matrix _ m) =
+    A.foldr A.append A.empty m
 
 
 

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -134,13 +134,15 @@ Generator function will be called for every element of matrix and will receive `
 generate : Int -> Int -> (Int -> Int -> a) -> Matrix a
 generate w h f =
     Matrix w <|
-        A.map
+        A.initialize
+            h
             (\y ->
-                A.map
+                A.initialize
+                    w
                     (\x -> f x y)
-                    (A.initialize w identity)
+                    
             )
-            (A.initialize h identity)
+            
 
 
 {-| indexedMap will call your function with `x`, `y` and `a` as params

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -105,7 +105,7 @@ Call `repeat` with width and height, and a value to be repeated.
 repeat : Int -> Int -> a -> Matrix a
 repeat w h a=
     Matrix w <|
-        (A.repeat w  (A.repeat h a))
+        (A.repeat h  (A.repeat w a))
 
 
 {-| Creates Matrix of given width and height by calling a generator function.

--- a/tests/MatrixTest.elm
+++ b/tests/MatrixTest.elm
@@ -94,15 +94,9 @@ suite =
                     m2 =
                         M.repeat w h 1
 
-                    mc =
-                        case concatHorizontal m1 m2 of
-                            Ok x ->
-                                x
-
-                            Err msg ->
-                                emptyMatrix
+                    mc = concatHorizontal m1 m2
                 in
-                Expect.equal (w * 2) (width mc)
+                Expect.equal (Ok <| w * 2) (Result.map width mc)
             )
         , fuzz2 rand1to10M
             rand1to10M
@@ -129,24 +123,15 @@ suite =
                     m2 =
                         M.repeat w h 1
 
-                    mc =
-                        case concatVertical m1 m2 of
-                            Ok x ->
-                                x
-
-                            Err msg ->
-                                emptyMatrix
+                    mc = concatVertical m1 m2
                 in
-                Expect.equal (h * 2) (height mc)
+                Expect.equal (Ok <| h * 2) (Result.map height mc)
             )
         ]
 
 
-{-| Empty Matrix
--}
-emptyMatrix : Matrix a
-emptyMatrix =
-    A.empty
+
+    
 
 
 numberOfDigits : Int -> Int

--- a/tests/NeighboursTest.elm
+++ b/tests/NeighboursTest.elm
@@ -81,78 +81,77 @@ arrayToString =
 
 neighboursTestSuite : Test
 neighboursTestSuite =
-    only <|
-        describe "Matrix Neighbours"
-            [ test
-                "Plane 0 0"
-                (\_ ->
-                    let
-                        n =
-                            N.neighbours N.Plane 0 0 testMatrix
-                    in
-                    Expect.true (arrayToString n) (haveSameElements n planeNeighbours_00)
-                )
-            , test
-                "Plane 1 1"
-                (\_ ->
-                    let
-                        n =
-                            N.neighbours N.Plane 1 1 testMatrix
-                    in
-                    Expect.true (arrayToString n) (haveSameElements n planeNeighbours_11)
-                )
-            , test
-                "Plane 3 3"
-                (\_ ->
-                    let
-                        n =
-                            N.neighbours N.Plane 3 3 testMatrix
-                    in
-                    Expect.true (arrayToString n) (haveSameElements n planeNeighbours_33)
-                )
-            , test
-                "Torus 0 0"
-                (\_ ->
-                    let
-                        n =
-                            N.neighbours N.Torus 0 0 testMatrix
-                    in
-                    Expect.true (arrayToString n) (haveSameElements n torusNeighbours_00)
-                )
-            , test
-                "Torus 1 1"
-                (\_ ->
-                    let
-                        n =
-                            N.neighbours N.Torus 1 1 testMatrix
-                    in
-                    Expect.true (arrayToString n) (haveSameElements n torusNeighbours_11)
-                )
-            , test
-                "Torus 3 3"
-                (\_ ->
-                    let
-                        n =
-                            N.neighbours N.Torus 3 3 testMatrix
-                    in
-                    Expect.true (arrayToString n) (haveSameElements n torusNeighbours_33)
-                )
-            , test
-                "Horizontal strip 0 0"
-                (\_ ->
-                    let
-                        n =
-                            N.neighbours N.StripHorizontal 0 0 testMatrix
-                    in
-                    Expect.true (arrayToString n) (haveSameElements n stripHorizontalNeighbours_00)
-                )
-            , test
-                "Vertical strip 0 0"
-                (\_ ->
-                    let
-                        n =
-                            N.neighbours N.StripVertical 0 0 testMatrix
-                    in
-                    Expect.true (arrayToString n) (haveSameElements n stripVerticalNeighbours_00)
-                )
-            ]
+    describe "Matrix Neighbours"
+        [ test
+            "Plane 0 0"
+            (\_ ->
+                let
+                    n =
+                        N.neighbours N.Plane 0 0 testMatrix
+                in
+                Expect.true (arrayToString n) (haveSameElements n planeNeighbours_00)
+            )
+        , test
+            "Plane 1 1"
+            (\_ ->
+                let
+                    n =
+                        N.neighbours N.Plane 1 1 testMatrix
+                in
+                Expect.true (arrayToString n) (haveSameElements n planeNeighbours_11)
+            )
+        , test
+            "Plane 3 3"
+            (\_ ->
+                let
+                    n =
+                        N.neighbours N.Plane 3 3 testMatrix
+                in
+                Expect.true (arrayToString n) (haveSameElements n planeNeighbours_33)
+            )
+        , test
+            "Torus 0 0"
+            (\_ ->
+                let
+                    n =
+                        N.neighbours N.Torus 0 0 testMatrix
+                in
+                Expect.true (arrayToString n) (haveSameElements n torusNeighbours_00)
+            )
+        , test
+            "Torus 1 1"
+            (\_ ->
+                let
+                    n =
+                        N.neighbours N.Torus 1 1 testMatrix
+                in
+                Expect.true (arrayToString n) (haveSameElements n torusNeighbours_11)
+            )
+        , test
+            "Torus 3 3"
+            (\_ ->
+                let
+                    n =
+                        N.neighbours N.Torus 3 3 testMatrix
+                in
+                Expect.true (arrayToString n) (haveSameElements n torusNeighbours_33)
+            )
+        , test
+            "Horizontal strip 0 0"
+            (\_ ->
+                let
+                    n =
+                        N.neighbours N.StripHorizontal 0 0 testMatrix
+                in
+                Expect.true (arrayToString n) (haveSameElements n stripHorizontalNeighbours_00)
+            )
+        , test
+            "Vertical strip 0 0"
+            (\_ ->
+                let
+                    n =
+                        N.neighbours N.StripVertical 0 0 testMatrix
+                in
+                Expect.true (arrayToString n) (haveSameElements n stripVerticalNeighbours_00)
+            )
+        ]


### PR DESCRIPTION
As discussed in previous PR, I've made Matrix an opaque type (I'm pretty sure it's breaking change: a user was able to build its own "matrix" with arrays, now I can't).

I've also clean the code a little bit (your tests was not all running because of a "only" in the NeigboursTest).